### PR TITLE
Before/After Hooks for selected operations

### DIFF
--- a/dmap.go
+++ b/dmap.go
@@ -32,6 +32,7 @@ type dmap struct {
 type DMap struct {
 	name string
 	db   *Olric
+	hooks map[int8][]HookHandler
 }
 
 // NewDMap creates an returns a new DMap instance.
@@ -48,6 +49,7 @@ func (db *Olric) NewDMap(name string) (*DMap, error) {
 	return &DMap{
 		name: name,
 		db:   db,
+		hooks: make(map[int8][]HookHandler),
 	}, nil
 }
 

--- a/dmap_hooks.go
+++ b/dmap_hooks.go
@@ -1,0 +1,24 @@
+package olric
+
+import "github.com/buraksezer/olric/internal/protocol"
+
+// Represents a hook handler
+//
+// Before operation hooks use the return values, however After operation hooks completely ignore these values
+type HookHandler func(key string, value interface{}) (modifiedKey string, modifiedValue interface{}, err error)
+
+const (
+	BeforePutHook   = int8(protocol.OpPut) * -1
+	AfterPutHook    = int8(protocol.OpPut)
+	AfterExpireHook = protocol.OpExpire
+)
+
+// Registers a handler
+func (dm *DMap) RegisterHook(hook int8, handler HookHandler) {
+	if harr, ok := dm.hooks[hook]; ok {
+		harr = append(harr, handler)
+		dm.hooks[hook] = harr // update
+	} else {
+		dm.hooks[hook] = []HookHandler{handler}
+	}
+}


### PR DESCRIPTION
Hi, as promised, here's the wish.

Although I must ask you, what you exactly mean by this comment in the documentation: 
`It is safe to modify the contents of the arguments after Put returns but not before.`

I hope you don't hate it that much :) let's discuss