### PR TITLE
bugfix/issue-82:  Remove unused and useless information from stats.Stats

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -109,7 +109,8 @@ func (c *Client) request(req protocol.EncodeDecoder) (protocol.EncodeDecoder, er
 	return c.client.RequestTo(addr, req)
 }
 
-// Stats exposes some useful metrics to monitor an Olric node.
+// Stats collects and returns Golang runtime metrics and partition statistics.
+// All data is belong to the given node. See stats.Stats for more information.
 func (c *Client) Stats(addr string) (stats.Stats, error) {
 	s := stats.Stats{}
 	req := protocol.NewSystemMessage(protocol.OpStats)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -153,9 +153,6 @@ func TestClient_Stats(t *testing.T) {
 			t.Fatalf("Expected Length is bigger than 0. Got: %d", part.Length)
 		}
 		totalByKeyCount += part.Length
-		if part.Owner.String() != addr {
-			t.Fatalf("Expected partition owner: %s. Got: %s", addr, part.Owner)
-		}
 	}
 	if totalByKeyCount != 100 {
 		t.Fatalf("Expected total length of partitions in stats is 100. Got: %d", total)

--- a/cmd/olric-stats/query/query.go
+++ b/cmd/olric-stats/query/query.go
@@ -58,11 +58,6 @@ func New(addr, timeout string, logger *log.Logger) (*Query, error) {
 
 func (q *Query) prettyPrint(partID uint64, part stats.Partition) {
 	q.log.Printf("PartID: %d", partID)
-	if len(part.Owner.String()) == 0 {
-		q.log.Printf("  Owner: not found")
-	} else {
-		q.log.Printf("  Owner: %s", part.Owner.String())
-	}
 	if len(part.PreviousOwners) != 0 {
 		q.log.Printf("  Previous Owners:")
 		for idx, previous := range part.PreviousOwners {
@@ -109,15 +104,13 @@ func (q *Query) PrintRawStats(backup bool) error {
 	if backup {
 		partitions = data.Backups
 	}
-	for partID := uint64(0); partID < uint64(len(partitions)); partID++ {
-		if part, ok := partitions[partID]; ok {
-			q.prettyPrint(partID, part)
-			totalLength += part.Length
-			for _, dm := range part.DMaps {
-				totalInuse += dm.SlabInfo.Inuse
-				totalAllocated += dm.SlabInfo.Allocated
-				totalGarbage += dm.SlabInfo.Garbage
-			}
+	for partID, part := range partitions {
+		q.prettyPrint(partID, part)
+		totalLength += part.Length
+		for _, dm := range part.DMaps {
+			totalInuse += dm.SlabInfo.Inuse
+			totalAllocated += dm.SlabInfo.Allocated
+			totalGarbage += dm.SlabInfo.Garbage
 		}
 	}
 	q.log.Printf("Summary for %s:\n\n", q.addr)

--- a/olric.go
+++ b/olric.go
@@ -73,7 +73,7 @@ var (
 )
 
 // ReleaseVersion is the current stable version of Olric
-const ReleaseVersion string = "0.3.0"
+const ReleaseVersion string = "0.3.7"
 
 const (
 	nilTimeout                = 0 * time.Second

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -15,11 +15,7 @@
 /*Package stats exposes internal data structures for Stat command*/
 package stats
 
-import (
-	"runtime"
-
-	"github.com/buraksezer/olric/internal/discovery"
-)
+import "runtime"
 
 // SlabInfo denotes memory usage of the storage engine(a hash indexed append only log file).
 type SlabInfo struct {
@@ -33,7 +29,7 @@ type SlabInfo struct {
 	Garbage int
 }
 
-// dmap denotes a distributed map instance on the cluster.
+// DMap denotes a distributed map instance on the cluster.
 type DMap struct {
 	Name   string
 	Length int
@@ -47,9 +43,8 @@ type DMap struct {
 
 // Partition denotes a partition and its metadata in the cluster.
 type Partition struct {
-	Owner          discovery.Member
-	PreviousOwners []discovery.Member
-	Backups        []discovery.Member
+	PreviousOwners []Member
+	Backups        []Member
 	Length         int
 	DMaps          map[string]DMap
 }
@@ -64,13 +59,25 @@ type Runtime struct {
 	MemStats     runtime.MemStats
 }
 
+// Member denotes a cluster member
+type Member struct {
+	Name      string
+	ID        uint64
+	Birthdate int64
+}
+
+func (m Member) String() string {
+	return m.Name
+}
+
 // Stats includes some metadata information about the cluster. The nodes add everything it knows about the cluster.
 type Stats struct {
 	Cmdline            []string
 	ReleaseVersion     string
 	Runtime            Runtime
-	ClusterCoordinator discovery.Member
+	ClusterCoordinator Member
+	Member             Member
 	Partitions         map[uint64]Partition
 	Backups            map[uint64]Partition
-	ClusterMembers     map[uint64]discovery.Member
+	ClusterMembers     map[uint64]Member
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -50,7 +50,7 @@ func TestStatsStandalone(t *testing.T) {
 		t.Fatalf("Expected nil. Got: %v", err)
 	}
 
-	if !cmpMembersByID(s.ClusterCoordinator, db.this) {
+	if s.ClusterCoordinator.String() != db.this.String() {
 		t.Fatalf("Expected cluster coordinator: %v. Got: %v", db.this, s.ClusterCoordinator)
 	}
 
@@ -77,9 +77,6 @@ func TestStatsStandalone(t *testing.T) {
 		}
 		if part.Length <= 0 {
 			t.Fatalf("Unexpected Length: %d", part.Length)
-		}
-		if !cmpMembersByID(part.Owner, db.this) {
-			t.Fatalf("Expected partition owner: %s. Got: %s", db.this, part.Owner)
 		}
 	}
 	if total != 100 {
@@ -150,7 +147,7 @@ func TestStatsCluster(t *testing.T) {
 			t.Fatalf("Expected nil. Got: %v", err)
 		}
 
-		if !cmpMembersByID(s.ClusterCoordinator, db1.this) {
+		if s.ClusterCoordinator.String() != db1.this.String() {
 			t.Fatalf("Expected cluster coordinator: %v. Got: %v", db1.this, s.ClusterCoordinator)
 		}
 	})

--- a/stats_test.go
+++ b/stats_test.go
@@ -162,12 +162,9 @@ func TestStatsCluster(t *testing.T) {
 		}
 
 		for _, member := range []discovery.Member{db1.this, db2.this} {
-			m, ok := s.ClusterMembers[member.ID]
+			_, ok := s.ClusterMembers[member.ID]
 			if !ok {
 				t.Fatalf("Member: %s could not be found in ClusterMembers", member)
-			}
-			if !reflect.DeepEqual(member, m) {
-				t.Fatalf("Different member for the same ID: %s", member)
 			}
 		}
 	})


### PR DESCRIPTION
We decided to remove unused/useless statistics from `Stats` output. Based on a historical and obviously wrong design decision, in the previous versions it collects and returns everything the node knows about the cluster. This behavior was wrong because, normally, a node should not know statistics about a partition it doesn't manage. So the output of `Stats` contains too much empty field about the cluster. 

With this PR, `Stats` only returns the current node's statistics. This is much more useful. 

The second problem was even worse than the above. `stats` package had an internal dependency. This problem has been eliminated. 
 
See #82 and `stats/stats.go` for more information about the case. 