### PR TITLE
Remove ineffectual t.Fatal() in goroutines

### DIFF
--- a/internal/streams/streams_test.go
+++ b/internal/streams/streams_test.go
@@ -83,7 +83,7 @@ func TestStream_CreateStream(t *testing.T) {
 	go func() {
 		err := client.CreateStream(ctx, c.MemberlistConfig.Name, readCh, writeCh)
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 		close(streamClosed)
 	}()
@@ -138,7 +138,7 @@ func TestStream_EchoMessage(t *testing.T) {
 	go func() {
 		err := client.CreateStream(ctx, c.MemberlistConfig.Name, readCh, writeCh)
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 		close(streamClosed)
 	}()
@@ -215,7 +215,7 @@ func TestStream_PingPong(t *testing.T) {
 	go func() {
 		err := client.CreateStream(ctx, c.MemberlistConfig.Name, readCh, writeCh)
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 		close(streamClosed)
 	}()

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -37,13 +37,13 @@ func TestClient_Request(t *testing.T) {
 	go func() {
 		err := s.ListenAndServe()
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	defer func() {
 		err = s.Shutdown(context.TODO())
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	<-s.StartedCtx.Done()

--- a/internal/transport/server_test.go
+++ b/internal/transport/server_test.go
@@ -85,7 +85,7 @@ func TestServer_ListenAndServe(t *testing.T) {
 	go func() {
 		err := s.ListenAndServe()
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	defer func() {
@@ -110,7 +110,7 @@ func TestServer_ProcessConn(t *testing.T) {
 	go func() {
 		err := s.ListenAndServe()
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	defer func() {
@@ -199,7 +199,7 @@ func TestServer_GracefulShutdown(t *testing.T) {
 	go func() {
 		err := s.ListenAndServe()
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	defer func() {
@@ -223,7 +223,7 @@ func TestServer_GracefulShutdown(t *testing.T) {
 		req := protocol.NewDMapMessage(protocol.OpPut)
 		_, err = c.RequestTo(s.listener.Addr().String(), req)
 		if err != io.EOF {
-			t.Fatalf("Expected io.EOF. Got: %v", err)
+			t.Errorf("Expected io.EOF. Got: %v", err)
 		}
 		cancel()
 	}()

--- a/internal/transport/stream_test.go
+++ b/internal/transport/stream_test.go
@@ -30,7 +30,7 @@ func TestClient_CreateStream(t *testing.T) {
 	go func() {
 		err := s.ListenAndServe()
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	defer func() {
@@ -80,7 +80,7 @@ func TestClient_CreateStream(t *testing.T) {
 	go func() {
 		err := c.CreateStream(ctx, addr, readCh, writeCh)
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 

--- a/internal/transport/timeout_test.go
+++ b/internal/transport/timeout_test.go
@@ -46,7 +46,7 @@ func TestConnWithTimeout(t *testing.T) {
 	go func() {
 		err := s.ListenAndServe()
 		if err != nil {
-			t.Fatalf("Expected nil. Got: %v", err)
+			t.Errorf("Expected nil. Got: %v", err)
 		}
 	}()
 	defer func() {
@@ -72,7 +72,7 @@ func TestConnWithTimeout(t *testing.T) {
 			req := protocol.NewDMapMessage(protocol.OpPut)
 			_, err := c.RequestTo(s.listener.Addr().String(), req)
 			if err.(*net.OpError).Err.Error() != "i/o timeout" {
-				t.Fatalf("Expected i/o timeout. Got: %v", err)
+				t.Errorf("Expected i/o timeout. Got: %v", err)
 			}
 		}()
 		select {
@@ -90,13 +90,13 @@ func TestConnWithTimeout(t *testing.T) {
 			req := protocol.NewDMapMessage(protocol.OpGet)
 			resp, err := c.RequestTo(s.listener.Addr().String(), req)
 			if err != nil {
-				t.Fatalf("Expected nil. Got: %v", err)
+				t.Errorf("Expected nil. Got: %v", err)
 			}
 			if resp.Status() != protocol.StatusOK {
-				t.Fatalf("Expected response status: %v. Got: %v", protocol.StatusOK, resp.Status())
+				t.Errorf("Expected response status: %v. Got: %v", protocol.StatusOK, resp.Status())
 			}
 			if !bytes.Equal(resp.Value(), value) {
-				t.Fatalf("Value in response is different")
+				t.Errorf("Value in response is different")
 			}
 		}()
 


### PR DESCRIPTION
Removes ineffectual calls to `testing.T.Fatal()` in goroutines.
`t.Fatal()` calls `runtime.GoExit()`, which only exits the current goroutine.

These were flagged by running `go vet ./...` locally. Non-critical for sure, just something my tools flagged as a warning.