### PR TITLE
v0.4: Skip runtime memory stats by default

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,6 +79,9 @@ func TestClient_Stats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected nil. Got: %v", err)
 	}
+	if s.Runtime != nil {
+		t.Error("Expected no runtime metrics. Got:", s.Runtime)
+	}
 
 	var totalByKeyCount int
 	var total int
@@ -101,5 +104,28 @@ func TestClient_Stats(t *testing.T) {
 	}
 	if total != 100 {
 		t.Fatalf("Expected total length of partitions in stats is 100. Got: %d", total)
+	}
+}
+
+func TestClient_Stats_CollectRuntime(t *testing.T) {
+	srv, err := testolric.New(t)
+	if err != nil {
+		t.Fatalf("Expected nil. Got %v", err)
+	}
+	tc := newTestConfig(srv)
+
+	c, err := New(tc)
+	if err != nil {
+		t.Fatalf("Expected nil. Got: %v", err)
+	}
+
+	addr := tc.Servers[0]
+	s, err := c.Stats(addr, CollectRuntime())
+	if err != nil {
+		t.Fatalf("Expected nil. Got: %v", err)
+	}
+
+	if s.Runtime == nil {
+		t.Error("Expected runtime metrics. Got nil")
 	}
 }

--- a/internal/protocol/extras.go
+++ b/internal/protocol/extras.go
@@ -66,7 +66,7 @@ type AtomicExtra struct {
 	Timestamp int64
 }
 
-// ExpireExtrrea defines extra values for this operation.
+// ExpireExtra defines extra values for this operation.
 type ExpireExtra struct {
 	TTL       int64
 	Timestamp int64
@@ -100,6 +100,10 @@ type DTopicAddListenerExtra struct {
 
 type DTopicRemoveListenerExtra struct {
 	ListenerID uint64
+}
+
+type StatsExtra struct {
+	CollectRuntime bool
 }
 
 func loadExtras(raw []byte, op OpCode) (interface{}, error) {
@@ -166,6 +170,10 @@ func loadExtras(raw []byte, op OpCode) (interface{}, error) {
 		return extra, err
 	case OpDTopicRemoveListener:
 		extra := DTopicRemoveListenerExtra{}
+		err := binary.Read(bytes.NewReader(raw), binary.BigEndian, &extra)
+		return extra, err
+	case OpStats:
+		extra := StatsExtra{}
 		err := binary.Read(bytes.NewReader(raw), binary.BigEndian, &extra)
 		return extra, err
 	default:

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -73,7 +73,7 @@ func (m Member) String() string {
 type Stats struct {
 	Cmdline            []string
 	ReleaseVersion     string
-	Runtime            Runtime
+	Runtime            *Runtime
 	ClusterCoordinator Member
 	Member             Member
 	Partitions         map[uint64]Partition

--- a/stats_test.go
+++ b/stats_test.go
@@ -45,6 +45,9 @@ func TestOlric_Stats(t *testing.T) {
 	assert.Equal(t, s.Member.Name, db.rt.This().Name)
 	assert.Equal(t, s.Member.ID, db.rt.This().ID)
 	assert.Equal(t, s.Member.Birthdate, db.rt.This().Birthdate)
+	if s.Runtime != nil {
+		t.Error("Runtime stats must not be collected by default:", s.Runtime)
+	}
 
 	var total int
 	for partID, part := range s.Partitions {
@@ -69,12 +72,25 @@ func TestOlric_Stats(t *testing.T) {
 	}
 }
 
+func TestOlric_Stats_CollectRuntime(t *testing.T) {
+	db, err := newTestOlric(t)
+	assert.NoError(t, err)
+
+	s, err := db.Stats(CollectRuntime())
+	assert.NoError(t, err)
+
+	if s.Runtime == nil {
+		t.Fatal("Runtime stats must be collected by default:", s.Runtime)
+	}
+}
+
 func TestOlric_Stats_Operation(t *testing.T) {
 	db, err := newTestOlric(t)
 	assert.NoError(t, err)
 
 	buf := new(bytes.Buffer)
 	req := protocol.NewSystemMessage(protocol.OpStats)
+	req.SetExtra(protocol.StatsExtra{})
 	req.SetBuffer(buf)
 	err = req.Encode()
 	assert.NoError(t, err)


### PR DESCRIPTION
Related https://github.com/buraksezer/olric/issues/82

Skips fetching runtime stats by default, but clients can opt-in. This prevents a call to `runtime.ReadMemStats()`, in turn skipping a call to `runtime.stopTheWorld()`.