### PR TITLE
Honor current TTL in DMap.Incr and DMap.Decr methods

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -93,7 +93,7 @@ func TestIntegration_NodesJoinOrLeftDuringQuery(t *testing.T) {
 }
 
 func TestIntegration_DMap_Cache_Eviction_LRU_MaxKeys(t *testing.T) {
-	var maxKeys = 100000
+	maxKeys := 100000
 	newConfig := func() *config.Config {
 		c := config.New("local")
 		c.PartitionCount = config.DefaultPartitionCount
@@ -142,7 +142,7 @@ func TestIntegration_DMap_Cache_Eviction_LRU_MaxKeys(t *testing.T) {
 }
 
 func TestIntegration_DMap_Cache_Eviction_MaxKeys(t *testing.T) {
-	var maxKeys = 100000
+	maxKeys := 100000
 	newConfig := func() *config.Config {
 		c := config.New("local")
 		c.PartitionCount = config.DefaultPartitionCount
@@ -198,7 +198,7 @@ func TestIntegration_DMap_Cache_Eviction_MaxKeys(t *testing.T) {
 }
 
 func TestIntegration_DMap_Cache_Eviction_MaxIdleDuration(t *testing.T) {
-	var maxKeys = 100000
+	maxKeys := 100000
 	newConfig := func() *config.Config {
 		c := config.New("local")
 		c.PartitionCount = config.DefaultPartitionCount
@@ -247,7 +247,7 @@ func TestIntegration_DMap_Cache_Eviction_MaxIdleDuration(t *testing.T) {
 }
 
 func TestIntegration_DMap_Cache_Eviction_TTLDuration(t *testing.T) {
-	var maxKeys = 100000
+	maxKeys := 100000
 	newConfig := func() *config.Config {
 		c := config.New("local")
 		c.PartitionCount = config.DefaultPartitionCount
@@ -285,7 +285,7 @@ func TestIntegration_DMap_Cache_Eviction_TTLDuration(t *testing.T) {
 	var total int
 
 	for i := 0; i < maxKeys; i++ {
-		_, err = dm.Get(ctx, fmt.Sprintf("mykey-%d", i))
+		_, err := dm.Get(ctx, fmt.Sprintf("mykey-%d", i))
 		if err == ErrKeyNotFound {
 			err = nil
 			total++
@@ -296,7 +296,7 @@ func TestIntegration_DMap_Cache_Eviction_TTLDuration(t *testing.T) {
 }
 
 func TestIntegration_DMap_Cache_Eviction_LRU_MaxInuse(t *testing.T) {
-	var maxKeys = 100000
+	maxKeys := 100000
 	newConfig := func() *config.Config {
 		c := config.New("local")
 		c.PartitionCount = config.DefaultPartitionCount

--- a/internal/dmap/atomic.go
+++ b/internal/dmap/atomic.go
@@ -82,8 +82,8 @@ func (dm *DMap) atomicIncrDecr(cmd string, e *env, delta int) (int, error) {
 	}()
 
 	if ttl != 0 {
-		e.putConfig.HasEX = true
-		e.putConfig.EX = time.Until(time.UnixMilli(ttl))
+		e.putConfig.HasPX = true
+		e.putConfig.PX = time.Until(time.UnixMilli(ttl))
 	}
 	err = dm.put(e)
 	if err != nil {

--- a/internal/dmap/atomic.go
+++ b/internal/dmap/atomic.go
@@ -18,29 +18,31 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/buraksezer/olric/internal/protocol"
 	"github.com/buraksezer/olric/internal/resp"
 	"github.com/buraksezer/olric/internal/util"
 	"github.com/buraksezer/olric/pkg/storage"
 )
 
-func (dm *DMap) loadCurrentAtomicInt(e *env) (int, error) {
+func (dm *DMap) loadCurrentAtomicInt(e *env) (int, int64, error) {
 	entry, err := dm.Get(e.ctx, e.key)
 	if errors.Is(err, ErrKeyNotFound) {
-		return 0, nil
+		return 0, 0, nil
 	}
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	if entry == nil {
-		return 0, nil
+		return 0, 0, nil
 	}
 	nr, err := util.ParseInt(entry.Value(), 10, 64)
 	if err != nil {
-		return 0, nil
+		return 0, 0, nil
 	}
-	return int(nr), nil
+	return int(nr), entry.TTL(), nil
 }
 
 func (dm *DMap) atomicIncrDecr(cmd string, e *env, delta int) (int, error) {
@@ -53,7 +55,7 @@ func (dm *DMap) atomicIncrDecr(cmd string, e *env, delta int) (int, error) {
 		}
 	}()
 
-	current, err := dm.loadCurrentAtomicInt(e)
+	current, ttl, err := dm.loadCurrentAtomicInt(e)
 	if err != nil {
 		return 0, err
 	}
@@ -79,6 +81,10 @@ func (dm *DMap) atomicIncrDecr(cmd string, e *env, delta int) (int, error) {
 		pool.Put(valueBuf)
 	}()
 
+	if ttl != 0 {
+		e.putConfig.HasEX = true
+		e.putConfig.EX = time.Until(time.UnixMilli(ttl))
+	}
 	err = dm.put(e)
 	if err != nil {
 		return 0, err

--- a/internal/dmap/atomic_test.go
+++ b/internal/dmap/atomic_test.go
@@ -56,10 +56,8 @@ func TestDMap_loadCurrentAtomicInt(t *testing.T) {
 	_, ttl, err := dm.loadCurrentAtomicInt(e)
 	require.NoError(t, err)
 
-	timePassed := time.Millisecond * 500
-	<-time.After(timePassed)
-	now := time.Now()
-	require.WithinDuration(t, time.UnixMilli(ttl), now, ttlDuration)
+	<-time.After(time.Millisecond * 500)
+	require.WithinDuration(t, time.UnixMilli(ttl), time.Now(), ttlDuration)
 }
 
 func TestDMap_Atomic_Incr(t *testing.T) {

--- a/internal/dmap/get.go
+++ b/internal/dmap/get.go
@@ -249,7 +249,7 @@ func (dm *DMap) readRepair(winner *version, versions []*version) {
 			}
 
 			f.Lock()
-			e := newEnv(nil)
+			e := newEnv(context.Background())
 			e.hkey = hkey
 			e.fragment = f
 			err = dm.putEntryOnFragment(e, winner.entry)


### PR DESCRIPTION
Since Incr and Decr operations internally do a Get followed by Put, the TTL value continuously . This change brings the following 2 changes to honor the TTL:
1. Update DMap.loadCurrentAtomicInt to return current TTL value from entry
2. Update DMAP.atomicIncrDecr to received the current TTL after calling DMap.loadCurrentAtomicInt and then update e.putConfig before putting the entry. This update signifies that the put contains an expiry and passes the new expiry value.