### PR TITLE
Feature: Bring back pipelining feature to Golang client

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,7 +27,7 @@ const DefaultScanCount = 10
 
 // Member denotes a member of the Olric cluster.
 type Member struct {
-	// Member name in the cluster
+	// Member name in the cluster. It's also host:port of the node.
 	Name string
 
 	// ID of the Member in the cluster. Hash of Name and Birthdate of the member
@@ -288,6 +288,8 @@ type Client interface {
 
 	// Members returns a thread-safe list of cluster members.
 	Members(ctx context.Context) ([]Member, error)
+
+	RefreshMetadata(ctx context.Context) error
 
 	// Close stops background routines and frees allocated resources.
 	Close(ctx context.Context) error

--- a/client.go
+++ b/client.go
@@ -178,7 +178,8 @@ type DMap interface {
 	// after being decremented or an error.
 	Decr(ctx context.Context, key string, delta int) (int, error)
 
-	// GetPut atomically sets the key to value and returns the old value stored at key.
+	// GetPut atomically sets the key to value and returns the old value stored at key. It returns nil if there is no
+	// previous value.
 	GetPut(ctx context.Context, key string, value interface{}) (*GetResponse, error)
 
 	// IncrByFloat atomically increments the key by delta. The return value is the new value

--- a/client.go
+++ b/client.go
@@ -289,6 +289,8 @@ type Client interface {
 	// Members returns a thread-safe list of cluster members.
 	Members(ctx context.Context) ([]Member, error)
 
+	// RefreshMetadata fetches a list of available members and the latest routing
+	// table version. It also closes stale clients, if there are any.
 	RefreshMetadata(ctx context.Context) error
 
 	// Close stops background routines and frees allocated resources.

--- a/client.go
+++ b/client.go
@@ -224,6 +224,8 @@ type DMap interface {
 	// is no global lock on DMaps. So if you call Put/PutEx and Destroy methods
 	// concurrently on the cluster, Put call may set new values to the DMap.
 	Destroy(ctx context.Context) error
+
+	Pipeline() (*DMapPipeline, error)
 }
 
 type statsConfig struct {

--- a/client.go
+++ b/client.go
@@ -225,6 +225,17 @@ type DMap interface {
 	// concurrently on the cluster, Put call may set new values to the DMap.
 	Destroy(ctx context.Context) error
 
+	// Pipeline is a mechanism to realise Redis Pipeline technique.
+	//
+	// Pipelining is a technique to extremely speed up processing by packing
+	// operations to batches, send them at once to Redis and read a replies in a
+	// singe step.
+	// See https://redis.io/topics/pipelining
+	//
+	// Pay attention, that Pipeline is not a transaction, so you can get unexpected
+	// results in case of big pipelines and small read/write timeouts.
+	// Redis client has retransmission logic in case of timeouts, pipeline
+	// can be retransmitted and commands can be executed more than once.
 	Pipeline() (*DMapPipeline, error)
 }
 

--- a/cluster_client.go
+++ b/cluster_client.go
@@ -246,7 +246,8 @@ func (dm *ClusterDMap) Decr(ctx context.Context, key string, delta int) (int, er
 	return int(res), nil
 }
 
-// GetPut atomically sets the key to value and returns the old value stored at key.
+// GetPut atomically sets the key to value and returns the old value stored at key. It returns nil if there is no
+// previous value.
 func (dm *ClusterDMap) GetPut(ctx context.Context, key string, value interface{}) (*GetResponse, error) {
 	rc, err := dm.clusterClient.smartPick(dm.name, key)
 	if err != nil {

--- a/cluster_client_test.go
+++ b/cluster_client_test.go
@@ -16,13 +16,13 @@ package olric
 
 import (
 	"context"
-	"github.com/buraksezer/olric/hasher"
 	"log"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/buraksezer/olric/config"
+	"github.com/buraksezer/olric/hasher"
 	"github.com/buraksezer/olric/internal/testutil"
 	"github.com/buraksezer/olric/stats"
 	"github.com/stretchr/testify/require"

--- a/cluster_iterator.go
+++ b/cluster_iterator.go
@@ -273,7 +273,7 @@ func (i *ClusterIterator) fetchRoutingTablePeriodically() {
 			return
 		case <-time.After(time.Second):
 			if err := i.fetchRoutingTable(); err != nil {
-				i.logger.Printf("[ERROR] Failed to fetch the latest routing table: %s", err)
+				i.logger.Printf("[ERROR] Failed to fetch the latest version of the routing table: %s", err)
 			}
 		}
 	}

--- a/embedded_client.go
+++ b/embedded_client.go
@@ -152,7 +152,8 @@ func (dm *EmbeddedDMap) Name() string {
 	return dm.name
 }
 
-// GetPut atomically sets the key to value and returns the old value stored at key.
+// GetPut atomically sets the key to value and returns the old value stored at key. It returns nil if there is no
+// previous value.
 func (dm *EmbeddedDMap) GetPut(ctx context.Context, key string, value interface{}) (*GetResponse, error) {
 	e, err := dm.dm.GetPut(ctx, key, value)
 	if err != nil {

--- a/embedded_client.go
+++ b/embedded_client.go
@@ -84,6 +84,9 @@ func (dm *EmbeddedDMap) Pipeline() (*DMapPipeline, error) {
 	return cdm.Pipeline()
 }
 
+// RefreshMetadata fetches a list of available members and the latest routing
+// table version. It also closes stale clients, if there are any. EmbeddedClient has
+// this method to implement the Client interface. It doesn't need to refresh metadata manually.
 func (e *EmbeddedClient) RefreshMetadata(_ context.Context) error {
 	// EmbeddedClient already has the latest metadata.
 	return nil

--- a/embedded_client.go
+++ b/embedded_client.go
@@ -61,6 +61,18 @@ type EmbeddedDMap struct {
 	storageEngine string
 }
 
+func (dm *EmbeddedDMap) Pipeline() (*DMapPipeline, error) {
+	cc, err := NewClusterClient([]string{dm.client.db.rt.This().String()})
+	if err != nil {
+		return nil, err
+	}
+	cdm, err := cc.NewDMap(dm.name)
+	if err != nil {
+		return nil, err
+	}
+	return cdm.Pipeline()
+}
+
 // Scan returns an iterator to loop over the keys.
 //
 // Available scan options:

--- a/embedded_client.go
+++ b/embedded_client.go
@@ -84,6 +84,11 @@ func (dm *EmbeddedDMap) Pipeline() (*DMapPipeline, error) {
 	return cdm.Pipeline()
 }
 
+func (e *EmbeddedClient) RefreshMetadata(_ context.Context) error {
+	// EmbeddedClient already has the latest metadata.
+	return nil
+}
+
 // Scan returns an iterator to loop over the keys.
 //
 // Available scan options:

--- a/embedded_client.go
+++ b/embedded_client.go
@@ -61,6 +61,17 @@ type EmbeddedDMap struct {
 	storageEngine string
 }
 
+// Pipeline is a mechanism to realise Redis Pipeline technique.
+//
+// Pipelining is a technique to extremely speed up processing by packing
+// operations to batches, send them at once to Redis and read a replies in a
+// singe step.
+// See https://redis.io/topics/pipelining
+//
+// Pay attention, that Pipeline is not a transaction, so you can get unexpected
+// results in case of big pipelines and small read/write timeouts.
+// Redis client has retransmission logic in case of timeouts, pipeline
+// can be retransmitted and commands can be executed more than once.
 func (dm *EmbeddedDMap) Pipeline() (*DMapPipeline, error) {
 	cc, err := NewClusterClient([]string{dm.client.db.rt.This().String()})
 	if err != nil {

--- a/olric.go
+++ b/olric.go
@@ -89,9 +89,11 @@ var (
 	// Maximum length of a key is 256 bytes.
 	ErrKeyTooLarge = errors.New("key too large")
 
-	// ErrEntryTooLarge returned if required space for an entry is bigger than table size.
+	// ErrEntryTooLarge returned if the required space for an entry is bigger than table size.
 	ErrEntryTooLarge = errors.New("entry too large for the configured table size")
 
+	// ErrConnRefused returned if the target node refused a connection request.
+	// It is good to call RefreshMetadata to update the underlying data structures.
 	ErrConnRefused = errors.New("connection refused")
 )
 

--- a/olric.go
+++ b/olric.go
@@ -91,6 +91,8 @@ var (
 
 	// ErrEntryTooLarge returned if required space for an entry is bigger than table size.
 	ErrEntryTooLarge = errors.New("entry too large for the configured table size")
+
+	ErrConnRefused = errors.New("connection refused")
 )
 
 // Olric implements a distributed cache and in-memory key/value data store.

--- a/pipeline.go
+++ b/pipeline.go
@@ -365,7 +365,7 @@ func (dp *DMapPipeline) Flush(ctx context.Context) error {
 	return errGr.Wait()
 }
 
-func (dm *ClusterDMap) Pipeline() *DMapPipeline {
+func (dm *ClusterDMap) Pipeline() (*DMapPipeline, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &DMapPipeline{
 		dm:       dm,
@@ -373,5 +373,5 @@ func (dm *ClusterDMap) Pipeline() *DMapPipeline {
 		result:   make(map[uint64][]redis.Cmder),
 		ctx:      ctx,
 		cancel:   cancel,
-	}
+	}, nil
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -372,6 +372,8 @@ func (dp *DMapPipeline) Flush(ctx context.Context) error {
 		partID := i
 		errGr.Go(func() error {
 			defer sem.Release(1)
+			// If flushOnPartition returns an error, it will eventually stop
+			// all flush operation.
 			return dp.flushOnPartition(ctx, partID)
 		})
 	}

--- a/pipeline.go
+++ b/pipeline.go
@@ -1,0 +1,240 @@
+// Copyright 2018-2022 Burak Sezer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olric
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/buraksezer/olric/internal/cluster/partitions"
+	"github.com/buraksezer/olric/internal/dmap"
+	"github.com/buraksezer/olric/internal/protocol"
+	"github.com/buraksezer/olric/internal/resp"
+	"github.com/go-redis/redis/v8"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+)
+
+var ErrNotReady = errors.New("not ready yet")
+
+type DMapPipeline struct {
+	mtx      sync.Mutex
+	dm       *ClusterDMap
+	commands map[uint64][]redis.Cmder
+	result   map[uint64][]redis.Cmder
+	ctx      context.Context
+	cancel   context.CancelFunc
+}
+
+func (dp *DMapPipeline) addCommand(key string, cmd redis.Cmder) (uint64, int) {
+	dp.mtx.Lock()
+	defer dp.mtx.Unlock()
+
+	hkey := partitions.HKey(dp.dm.name, key)
+	partID := hkey % dp.dm.clusterClient.partitionCount
+
+	dp.commands[partID] = append(dp.commands[partID], cmd)
+
+	return partID, len(dp.commands[partID]) - 1
+}
+
+type FuturePut struct {
+	dp     *DMapPipeline
+	partID uint64
+	index  int
+	ctx    context.Context
+}
+
+func (f *FuturePut) Result() error {
+	select {
+	case <-f.ctx.Done():
+		cmd := f.dp.result[f.partID][f.index]
+		return processProtocolError(cmd.Err())
+	default:
+		return ErrNotReady
+	}
+}
+
+func (dp *DMapPipeline) Put(ctx context.Context, key string, value interface{}, options ...PutOption) (*FuturePut, error) {
+	buf := bytes.NewBuffer(nil)
+
+	enc := resp.New(buf)
+	err := enc.Encode(value)
+	if err != nil {
+		return nil, err
+	}
+
+	var pc dmap.PutConfig
+	for _, opt := range options {
+		opt(&pc)
+	}
+
+	cmd := dp.dm.writePutCommand(&pc, key, buf.Bytes()).Command(ctx)
+	partID, index := dp.addCommand(key, cmd)
+	return &FuturePut{
+		dp:     dp,
+		partID: partID,
+		index:  index,
+		ctx:    dp.ctx,
+	}, nil
+}
+
+type FutureGet struct {
+	dp     *DMapPipeline
+	partID uint64
+	index  int
+	ctx    context.Context
+}
+
+func (f *FutureGet) Result() (*GetResponse, error) {
+	select {
+	case <-f.ctx.Done():
+		cmd := f.dp.result[f.partID][f.index]
+		if cmd.Err() != nil {
+			return nil, processProtocolError(cmd.Err())
+		}
+		scmd := redis.NewStringCmd(context.Background(), cmd.Args()...)
+		scmd.SetVal(cmd.(*redis.Cmd).Val().(string))
+		return f.dp.dm.makeGetResponse(scmd)
+	default:
+		return nil, ErrNotReady
+	}
+}
+
+func (dp *DMapPipeline) Get(ctx context.Context, key string) *FutureGet {
+	cmd := protocol.NewGet(dp.dm.name, key).SetRaw().Command(ctx)
+	partID, index := dp.addCommand(key, cmd)
+	return &FutureGet{
+		dp:     dp,
+		partID: partID,
+		index:  index,
+		ctx:    dp.ctx,
+	}
+}
+
+type FutureDelete struct {
+	dp     *DMapPipeline
+	partID uint64
+	index  int
+	ctx    context.Context
+}
+
+func (f *FutureDelete) Result() (int, error) {
+	select {
+	case <-f.ctx.Done():
+		cmd := f.dp.result[f.partID][f.index]
+		if cmd.Err() != nil {
+			return 0, processProtocolError(cmd.Err())
+		}
+		return int(cmd.(*redis.Cmd).Val().(int64)), nil
+	default:
+		return 0, ErrNotReady
+	}
+}
+
+func (dp *DMapPipeline) Delete(ctx context.Context, key string) *FutureDelete {
+	cmd := protocol.NewDel(dp.dm.name, []string{key}...).Command(ctx)
+	partID, index := dp.addCommand(key, cmd)
+	return &FutureDelete{
+		dp:     dp,
+		partID: partID,
+		index:  index,
+		ctx:    dp.ctx,
+	}
+}
+
+type FutureExpire struct {
+	dp     *DMapPipeline
+	partID uint64
+	index  int
+	ctx    context.Context
+}
+
+func (f *FutureExpire) Result() error {
+	select {
+	case <-f.ctx.Done():
+		cmd := f.dp.result[f.partID][f.index]
+		return processProtocolError(cmd.Err())
+	default:
+		return ErrNotReady
+	}
+}
+
+func (dp *DMapPipeline) Expire(ctx context.Context, key string, timeout time.Duration) (*FutureExpire, error) {
+	cmd := protocol.NewExpire(dp.dm.name, key, timeout).Command(ctx)
+	partID, index := dp.addCommand(key, cmd)
+	return &FutureExpire{
+		dp:     dp,
+		partID: partID,
+		index:  index,
+		ctx:    dp.ctx,
+	}, nil
+}
+
+func (dp *DMapPipeline) flushOnPartition(ctx context.Context, partID uint64) error {
+	rc, err := dp.dm.clusterClient.clientByPartID(partID)
+	if err != nil {
+		return err
+	}
+	commands := dp.commands[partID]
+	pipe := rc.Pipeline()
+
+	for _, cmd := range commands {
+		pipe.Do(ctx, cmd.Args()...)
+	}
+
+	result, err := pipe.Exec(ctx)
+	if err != nil {
+		return err
+	}
+	dp.result[partID] = result
+	return nil
+}
+
+func (dp *DMapPipeline) Flush(ctx context.Context) error {
+	dp.mtx.Lock()
+	defer dp.mtx.Unlock()
+
+	defer dp.cancel()
+
+	var errGr errgroup.Group
+	numCpu := 1
+	sem := semaphore.NewWeighted(int64(numCpu))
+	for i := uint64(0); i < dp.dm.clusterClient.partitionCount; i++ {
+		_ = sem.Acquire(ctx, 1)
+
+		partID := i
+		errGr.Go(func() error {
+			defer sem.Release(1)
+			return dp.flushOnPartition(ctx, partID)
+		})
+	}
+
+	return errGr.Wait()
+}
+
+func (dm *ClusterDMap) Pipeline() *DMapPipeline {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &DMapPipeline{
+		dm:       dm,
+		commands: make(map[uint64][]redis.Cmder),
+		result:   make(map[uint64][]redis.Cmder),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -39,7 +39,9 @@ func TestDMapPipeline_Put(t *testing.T) {
 	require.NoError(t, err)
 
 	futures := make(map[int]*FuturePut)
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	for i := 0; i < 100; i++ {
 		fp, err := pipe.Put(ctx, testutil.ToKey(i), testutil.ToVal(i))
 		require.NoError(t, err)
@@ -81,7 +83,9 @@ func TestDMapPipeline_Get(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	futures := make(map[int]*FutureGet)
 	for i := 0; i < 100; i++ {
 		fg := pipe.Get(ctx, testutil.ToKey(i))
@@ -119,7 +123,9 @@ func TestDMapPipeline_Delete(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	futures := make(map[int]*FutureDelete)
 	for i := 0; i < 100; i++ {
 		fd := pipe.Delete(ctx, testutil.ToKey(i))
@@ -154,7 +160,9 @@ func TestDMapPipeline_Expire(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	futures := make(map[int]*FutureExpire)
 	for i := 0; i < 100; i++ {
 		fd, err := pipe.Expire(ctx, testutil.ToKey(i), time.Hour)
@@ -192,7 +200,9 @@ func TestDMapPipeline_Incr(t *testing.T) {
 	require.NoError(t, err)
 
 	futures := make(map[int]*FutureIncr)
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	for i := 0; i < 100; i++ {
 		fi, err := pipe.Incr(ctx, "mykey", 1)
 		require.NoError(t, err)
@@ -223,7 +233,9 @@ func TestDMapPipeline_Decr(t *testing.T) {
 	require.NoError(t, err)
 
 	futures := make(map[int]*FutureDecr)
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	for i := 0; i < 100; i++ {
 		fi, err := pipe.Decr(ctx, "mykey", 1)
 		require.NoError(t, err)
@@ -254,7 +266,9 @@ func TestDMapPipeline_GetPut(t *testing.T) {
 	require.NoError(t, err)
 
 	futures := make(map[int]*FutureGetPut)
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	for i := 0; i < 100; i++ {
 		fi, err := pipe.GetPut(ctx, testutil.ToKey(i), testutil.ToVal(i))
 		require.NoError(t, err)
@@ -287,7 +301,9 @@ func TestDMapPipeline_IncrByFloat(t *testing.T) {
 	require.NoError(t, err)
 
 	futures := make(map[int]*FutureIncrByFloat)
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	require.NoError(t, err)
+
 	for i := 0; i < 100; i++ {
 		fi, err := pipe.IncrByFloat(ctx, "mykey", 1.2)
 		require.NoError(t, err)
@@ -314,7 +330,10 @@ func ExamplePipeline() {
 
 	ctx := context.Background()
 
-	pipe := dm.(*ClusterDMap).Pipeline()
+	pipe, err := dm.Pipeline()
+	if err != nil {
+		// Handle this error
+	}
 
 	futurePut, err := pipe.Put(ctx, "key-1", "value-1")
 	if err != nil {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -48,7 +48,7 @@ func TestDMapPipeline_Put(t *testing.T) {
 		require.NoError(t, err)
 		futures[i] = fp
 	}
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for _, fp := range futures {
@@ -94,7 +94,7 @@ func TestDMapPipeline_Get(t *testing.T) {
 		futures[i] = fg
 	}
 
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for i, fg := range futures {
@@ -135,7 +135,7 @@ func TestDMapPipeline_Delete(t *testing.T) {
 		futures[i] = fd
 	}
 
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for _, fd := range futures {
@@ -174,7 +174,7 @@ func TestDMapPipeline_Expire(t *testing.T) {
 		futures[i] = fd
 	}
 
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for _, fd := range futures {
@@ -213,7 +213,7 @@ func TestDMapPipeline_Incr(t *testing.T) {
 		require.NoError(t, err)
 		futures[i] = fi
 	}
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for i, fp := range futures {
@@ -247,7 +247,7 @@ func TestDMapPipeline_Decr(t *testing.T) {
 		require.NoError(t, err)
 		futures[i] = fi
 	}
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for i, fp := range futures {
@@ -281,7 +281,7 @@ func TestDMapPipeline_GetPut(t *testing.T) {
 		require.NoError(t, err)
 		futures[i] = fi
 	}
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for _, fp := range futures {
@@ -317,7 +317,7 @@ func TestDMapPipeline_IncrByFloat(t *testing.T) {
 		require.NoError(t, err)
 		futures[i] = fi
 	}
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for _, fp := range futures {
@@ -354,7 +354,7 @@ func TestDMapPipeline_Discard(t *testing.T) {
 	err = pipe.Discard()
 	require.NoError(t, err)
 
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.NoError(t, err)
 
 	for i := 0; i < 100; i++ {
@@ -390,7 +390,7 @@ func TestDMapPipeline_Close(t *testing.T) {
 
 	pipe.Close()
 
-	err = pipe.Flush(ctx)
+	err = pipe.Exec(ctx)
 	require.ErrorIs(t, err, ErrPipelineClosed)
 }
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -277,7 +277,7 @@ func TestDMapPipeline_GetPut(t *testing.T) {
 	defer pipe.Close()
 
 	for i := 0; i < 100; i++ {
-		fi, err := pipe.GetPut(ctx, testutil.ToKey(i), testutil.ToVal(i))
+		fi, err := pipe.GetPut(ctx, "key", testutil.ToVal(i))
 		require.NoError(t, err)
 		futures[i] = fi
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,207 @@
+// Copyright 2018-2022 Burak Sezer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olric
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/buraksezer/olric/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDMapPipeline_Put(t *testing.T) {
+	cluster := newTestOlricCluster(t)
+	db := cluster.addMember(t)
+
+	ctx := context.Background()
+	c, err := NewClusterClient([]string{db.name})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, c.Close(ctx))
+	}()
+
+	dm, err := c.NewDMap("mydmap")
+	require.NoError(t, err)
+
+	futures := make(map[int]*FuturePut)
+	pipe := dm.(*ClusterDMap).Pipeline()
+	for i := 0; i < 100; i++ {
+		fp, err := pipe.Put(ctx, testutil.ToKey(i), testutil.ToVal(i))
+		require.NoError(t, err)
+		futures[i] = fp
+	}
+	err = pipe.Flush(ctx)
+	require.NoError(t, err)
+
+	for _, fp := range futures {
+		require.NoError(t, fp.Result())
+	}
+
+	for i := 0; i < 100; i++ {
+		key := testutil.ToKey(i)
+		gr, err := dm.Get(ctx, key)
+		require.NoError(t, err)
+
+		value, err := gr.Byte()
+		require.NoError(t, err)
+		require.Equal(t, testutil.ToVal(i), value)
+	}
+}
+
+func TestDMapPipeline_Get(t *testing.T) {
+	cluster := newTestOlricCluster(t)
+	db := cluster.addMember(t)
+
+	ctx := context.Background()
+	c, err := NewClusterClient([]string{db.name})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, c.Close(ctx))
+	}()
+
+	dm, err := c.NewDMap("mydmap")
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err = dm.Put(ctx, testutil.ToKey(i), testutil.ToVal(i))
+		require.NoError(t, err)
+	}
+
+	pipe := dm.(*ClusterDMap).Pipeline()
+	futures := make(map[int]*FutureGet)
+	for i := 0; i < 100; i++ {
+		fg := pipe.Get(ctx, testutil.ToKey(i))
+		futures[i] = fg
+	}
+
+	err = pipe.Flush(ctx)
+	require.NoError(t, err)
+
+	for i, fg := range futures {
+		gr, err := fg.Result()
+		require.NoError(t, err)
+
+		value, err := gr.Byte()
+		require.NoError(t, err)
+		require.Equal(t, testutil.ToVal(i), value)
+	}
+}
+
+func TestDMapPipeline_Delete(t *testing.T) {
+	cluster := newTestOlricCluster(t)
+	db := cluster.addMember(t)
+
+	ctx := context.Background()
+	c, err := NewClusterClient([]string{db.name})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, c.Close(ctx))
+	}()
+
+	dm, err := c.NewDMap("mydmap")
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err = dm.Put(ctx, testutil.ToKey(i), testutil.ToVal(i))
+		require.NoError(t, err)
+	}
+
+	pipe := dm.(*ClusterDMap).Pipeline()
+	futures := make(map[int]*FutureDelete)
+	for i := 0; i < 100; i++ {
+		fd := pipe.Delete(ctx, testutil.ToKey(i))
+		futures[i] = fd
+	}
+
+	err = pipe.Flush(ctx)
+	require.NoError(t, err)
+
+	for _, fd := range futures {
+		num, err := fd.Result()
+		require.NoError(t, err)
+		require.Equal(t, 1, num)
+	}
+}
+
+func TestDMapPipeline_Expire(t *testing.T) {
+	cluster := newTestOlricCluster(t)
+	db := cluster.addMember(t)
+
+	ctx := context.Background()
+	c, err := NewClusterClient([]string{db.name})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, c.Close(ctx))
+	}()
+
+	dm, err := c.NewDMap("mydmap")
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		err = dm.Put(ctx, testutil.ToKey(i), testutil.ToVal(i))
+		require.NoError(t, err)
+	}
+
+	pipe := dm.(*ClusterDMap).Pipeline()
+	futures := make(map[int]*FutureExpire)
+	for i := 0; i < 100; i++ {
+		fd, err := pipe.Expire(ctx, testutil.ToKey(i), time.Hour)
+		require.NoError(t, err)
+		futures[i] = fd
+	}
+
+	err = pipe.Flush(ctx)
+	require.NoError(t, err)
+
+	for _, fd := range futures {
+		err := fd.Result()
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < 100; i++ {
+		gr, err := dm.Get(ctx, testutil.ToKey(i))
+		require.NoError(t, err)
+		require.NotEqual(t, int64(0), gr.TTL())
+	}
+}
+
+func ExamplePipeline() {
+	c, err := NewClusterClient([]string{"127.0.0.1:3320"})
+	if err != nil {
+		// Handle this error
+	}
+	dm, err := c.NewDMap("mydmap")
+	if err != nil {
+		// Handle this error
+	}
+
+	ctx := context.Background()
+
+	pipe := dm.(*ClusterDMap).Pipeline()
+
+	futurePut, err := pipe.Put(ctx, "key-1", "value-1")
+	if err != nil {
+		// Handle this error
+	}
+
+	err = pipe.Flush(context.Background())
+	if err != nil {
+		// Handle this error
+	}
+
+	err = futurePut.Result()
+	if err != nil {
+		// Handle this error
+	}
+}


### PR DESCRIPTION
This PR implements Redis Pipelining in the Golang Client, both `ClusterClient` and `EmbeddedClient`. See #173 

Here is a sample:

```go
func ExamplePipeline() {
	c, err := NewClusterClient([]string{"127.0.0.1:3320"})
	if err != nil {
		// Handle this error
	}
	dm, err := c.NewDMap("mydmap")
	if err != nil {
		// Handle this error
	}

	ctx := context.Background()

	pipe, err := dm.Pipeline()
	if err != nil {
		// Handle this error
	}

	futurePut, err := pipe.Put(ctx, "key-1", "value-1")
	if err != nil {
		// Handle this error
	}

	futureGet := pipe.Get(ctx, "key-1")

	err = pipe.Exec(context.Background())
	if err != nil {
		// Handle this error
	}

	err = futurePut.Result()
	if err != nil {
		// Handle this error
	}

	gr, err := futureGet.Result()
	if err != nil {
		// Handle this error
	}
	value, err := gr.String()
	if err != nil {
		// Handle this error
	}
	fmt.Println(value)
}
```