### PR TITLE
reduce pipeline allocations

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -445,8 +445,14 @@ func (dp *DMapPipeline) Discard() error {
 	dp.mtx.Lock()
 	defer dp.mtx.Unlock()
 
-	dp.commands = make(map[uint64][]redis.Cmder)
-	dp.result = make(map[uint64][]redis.Cmder)
+	for k := range dp.commands {
+		delete(dp.commands, k)
+	}
+
+	for k := range dp.result {
+		delete(dp.result, k)
+	}
+
 	dp.ctx, dp.cancel = context.WithCancel(context.Background())
 	return nil
 }


### PR DESCRIPTION
Walking through the code, it seems to be clear that there is no reuse of the commands. As written, calls to `FutureXXX` after calling Discard would either return invalid data or panic, so this doesn't alter that undefined behavior.

Resolves #203 