### PR TITLE
feat: separate Exec ctx and Closed ctx

### DIFF
--- a/client.go
+++ b/client.go
@@ -236,7 +236,17 @@ type DMap interface {
 	// results in case of big pipelines and small read/write timeouts.
 	// Redis client has retransmission logic in case of timeouts, pipeline
 	// can be retransmitted and commands can be executed more than once.
-	Pipeline() (*DMapPipeline, error)
+	Pipeline(opts ...PipelineOption) (*DMapPipeline, error)
+}
+
+// PipelineOption is a function for defining options to control behavior of the Pipeline command.
+type PipelineOption func(pipeline *DMapPipeline)
+
+// PipelineConcurrency is a PipelineOption controlling the number of concurrent goroutines.
+func PipelineConcurrency(concurrency int) PipelineOption {
+	return func(dp *DMapPipeline) {
+		dp.concurrency = concurrency
+	}
 }
 
 type statsConfig struct {

--- a/embedded_client.go
+++ b/embedded_client.go
@@ -72,7 +72,7 @@ type EmbeddedDMap struct {
 // results in case of big pipelines and small read/write timeouts.
 // Redis client has retransmission logic in case of timeouts, pipeline
 // can be retransmitted and commands can be executed more than once.
-func (dm *EmbeddedDMap) Pipeline() (*DMapPipeline, error) {
+func (dm *EmbeddedDMap) Pipeline(opts ...PipelineOption) (*DMapPipeline, error) {
 	cc, err := NewClusterClient([]string{dm.client.db.rt.This().String()})
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (dm *EmbeddedDMap) Pipeline() (*DMapPipeline, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cdm.Pipeline()
+	return cdm.Pipeline(opts...)
 }
 
 // RefreshMetadata fetches a list of available members and the latest routing


### PR DESCRIPTION
#### `feat: add PipelineConcurrency option`
This adds a pipeline option to the DMap pipeline interface, which should be backwards compatible. It also changes the default from 1 to runtime.NumCPU(), which from the variable naming, appears to have been the original intent.

fixes #201 

#### `feat: separate Exec ctx and Closed ctx`
- fixes a bug where Discard would always return ErrPipelineClosed after calling Exec, making it impossible to reuse it
- protects FutureXXX calls from panicking or returning stale/invalid data

fixes #205

~This is rebased on top of #202 to avoid merge conflicts, so we should either merge that one first, or close it and use this PR for both.~

The second commit is extra noisy because the `closedCtx` field caused indentation changes to happen on all pipeline structs